### PR TITLE
Avoid return negative weight

### DIFF
--- a/src/Method.php
+++ b/src/Method.php
@@ -41,9 +41,9 @@ class Method
 
     public function getWeight(): int
     {
-        return $this->getLine() * $this->countArguments() > 0
-            ? $this->getLine() * $this->countArguments()
-            : 0;
+        $weight = $this->getLine() * $this->countArguments();
+
+        return $weight > 0 ? $weight : 0;
     }
 
     public function isConstructor(): bool

--- a/src/Method.php
+++ b/src/Method.php
@@ -41,7 +41,9 @@ class Method
 
     public function getWeight(): int
     {
-        return $this->getLine() * $this->countArguments();
+        return $this->getLine() * $this->countArguments() > 0
+            ? $this->getLine() * $this->countArguments()
+            : 0;
     }
 
     public function isConstructor(): bool


### PR DESCRIPTION
When showing results, if there's an interface in the scanned folder that has methods with arguments, it returns a negative weight (-2 * args), because of getLine() method it substracts always 2 (I guess its for the curly braces of the method).
